### PR TITLE
Prevent a PHP warning in the debug.log when $post isn't an object

### DIFF
--- a/Loader.php
+++ b/Loader.php
@@ -34,7 +34,7 @@ class Loader {
 		
 		$test_template = '';
 		
-		if ( is_object( $post ){
+		if ( is_object( $post ) ){
 			$test_template = get_post_meta( $post->ID, '_test_template', true );
 		}
 

--- a/Loader.php
+++ b/Loader.php
@@ -31,8 +31,12 @@ class Loader {
 	 */
 	public function load_template( $template ) {
 		global $post;
-
-		$test_template = get_post_meta( $post->ID, '_test_template', true );
+		
+		$test_template = '';
+		
+		if ( is_object( $post ){
+			$test_template = get_post_meta( $post->ID, '_test_template', true );
+		}
 
 		if ( ! $test_template ) {
 			return $template;


### PR DESCRIPTION
In several cases, a PHP warning about trying to accces `ID` of a non-object appears in the `debug.log` "polluting" it.

With this PR a check is done to see if `$post` is an object.